### PR TITLE
fixed red outline on custom defaults in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -262,7 +262,7 @@ You can set custom default arguments by creating a file `config.json` in the mai
 
 ```json
 {
-    "verbose": 3,
+    "verbose": 3,
     "no_docker": true
 }
 ```


### PR DESCRIPTION
I genuinely have no clue why it was there or why just rewriting the line fixed it.