### PR TITLE
Removed need for Vosk model download step in certain cases

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,7 @@ npm i
 ```
 
 - Install Vosk model through the [Vosk website](https://alphacephei.com/vosk/models) or using the automatic tool. **This is a 1.8 GB file and thus will take some time, please have patience.**
+  - Note that this step is only necessary if `aligning_algorithm` is `allosaurus` (non-default), or: `aligning_algorithm` is `gentle` (default), `transcriber` is `vosk` (default), and no script text-file is supplied (ie. using `--text <path>`).
 
 ```cmd
 npm run downloadModel
@@ -101,6 +102,7 @@ npm i
 ```
 
 - Install Vosk model through the [Vosk website](https://alphacephei.com/vosk/models) or using the automatic tool. **This is a 1.6 GB file and thus will take some time, please have patience.**
+  - Note that this step is only necessary if `aligning_algorithm` is `allosaurus` (non-default), or: `aligning_algorithm` is `gentle` (default), `transcriber` is `vosk` (default), and no script text-file is supplied (ie. using `--text <path>`).
 
 ```bash
 npm run downloadModel
@@ -149,6 +151,7 @@ npm i
 ```
 
 - Install Vosk model through the [Vosk website](https://alphacephei.com/vosk/models) or using the automatic tool. **This is a 1.6 GB file and thus will take some time, please have patience. There is currently no progress bar implemented.**
+  - Note that this step is only necessary if `aligning_algorithm` is `allosaurus` (non-default), or: `aligning_algorithm` is `gentle` (default), `transcriber` is `vosk` (default), and no script text-file is supplied (ie. using `--text <path>`).
 
 ```zsh
 npm run downloadModel

--- a/src/transcriber.ts
+++ b/src/transcriber.ts
@@ -3,7 +3,6 @@ import { Readable } from "stream";
 import wav from "wav";
 import { join } from "path";
 import { execSync } from "child_process";
-var vosk = require("vosk");
 
 interface VoskTimestamp {
   start: number;
@@ -74,6 +73,8 @@ export async function voskTranscribe(
   model_path: string,
 
 ): Promise<VoskOut> {
+  var vosk = require("vosk");
+
   vosk.setLogLevel(-1);
   const model = new vosk.Model(model_path);
 


### PR DESCRIPTION
* Fixed that transcriber.ts would error at module-load time (due to a missing Vosk model), even if the user-supplied arguments did not require usage of the Vosk model at all.
* Updated readme to clarify that the step of downloading the Vosk model (which takes several minutes) is only needed for certain combinations of arguments.

Fixes #58 